### PR TITLE
Add WooCommerce plugin skeleton with DHL tracking module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # woocommerce-kingbear-adapter
-Tool zur Verknüpfung der Versandabwicklung mit externen Ressourcen
+
+Plugin für WooCommerce, das Versandabwicklung und Sendungsverfolgung modular bereitstellt.
+
+## Aufbau
+- **Plugin** lädt Module und stellt einen Einstellungs-Tab in den WooCommerce-Einstellungen bereit.
+- **Module**: "Sendungsverfolgung" (implementiert), "Versandabwicklung" und "Alexa" (Platzhalter).
+
+## Sendungsverfolgung
+- Speichert Tracking-Daten als `KB_Tracking` basierend auf `WC_Data`.
+- Cron-Job alle 30 Minuten ruft die DHL Paket API (`d-get-piece-detail`) mit bis zu 15 Tracking-IDs ab.
+- Aktualisiert Status, Zeitstempel, Events sowie Zustell- und Rücksende-Flag.
+- Bei Zustellung (Flag `delivered`), ist ein Update des zugehörigen Shiptastic-Shipment vorgesehen.
+- Admin-Seite unter `WooCommerce → Sendungsverfolgung` listet alle Sendungen mit Zeitstempel, Tracking-ID, Empfänger und Status.
+
+### Einstellungen
+Unter `WooCommerce → Einstellungen → KingBear Adapter` können pro Modul Parameter gepflegt werden. Für die Sendungsverfolgung:
+- DHL API Key & Secret
+- DHL Benutzername & Passwort
+- Logging: nur Fehler oder zusätzlich Debug-Infos
+
+## Aufgabenübersicht
+- Automatische Updates über GitHub-Releases (Plugin-Header-Version).
+- Modularer Aufbau mit kommunizierenden Modulen.
+- Logging über WooCommerce-Logger, Level im Backend konfigurierbar.
+- Fehler sollen abgefangen werden, um Totalausfälle zu vermeiden.
+

--- a/includes/class-kb-plugin.php
+++ b/includes/class-kb-plugin.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Hauptklasse des KingBear Plugins.
+ *
+ * @package WooCommerce_KingBear_Adapter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class KB_Plugin {
+
+    const VERSION = '0.1.0';
+
+    /**
+     * Singleton Instanz.
+     *
+     * @var KB_Plugin|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Geladene Module.
+     *
+     * @var array
+     */
+    protected $modules = array();
+
+    /**
+     * Liefert die Plugin Instanz.
+     *
+     * @return KB_Plugin
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'plugins_loaded', array( $this, 'init' ) );
+    }
+
+    /**
+     * Initialisiert das Plugin.
+     */
+    public function init() {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return; // Stoppe wenn WooCommerce nicht verfügbar ist.
+        }
+
+        require_once __DIR__ . '/class-kb-settings-page.php';
+        $this->load_modules();
+
+        add_filter( 'woocommerce_get_settings_pages', array( $this, 'register_settings_page' ) );
+        add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
+    }
+
+    /**
+     * Lädt alle Modulen.
+     */
+    protected function load_modules() {
+        require_once __DIR__ . '/../modules/tracking/class-kb-tracking-module.php';
+        $this->modules['tracking'] = new KB_Tracking_Module();
+    }
+
+    /**
+     * Registriert Einstellungsseite.
+     *
+     * @param array $pages Vorhandene Seiten.
+     * @return array
+     */
+    public function register_settings_page( $pages ) {
+        $pages[] = new KB_Settings_Page( $this->modules );
+        return $pages;
+    }
+
+    /**
+     * Fügt die Admin-Seite zur Sendungsverfolgung hinzu.
+     */
+    public function register_admin_menu() {
+        if ( isset( $this->modules['tracking'] ) ) {
+            add_submenu_page(
+                'woocommerce',
+                __( 'Sendungsverfolgung', 'kb' ),
+                __( 'Sendungsverfolgung', 'kb' ),
+                'manage_woocommerce',
+                'kb-tracking',
+                array( $this->modules['tracking'], 'render_admin_page' )
+            );
+        }
+    }
+
+    /**
+     * Plugin Aktivierung.
+     */
+    public static function activate() {
+        KB_Tracking_Module::schedule_cron();
+    }
+
+    /**
+     * Plugin Deaktivierung.
+     */
+    public static function deactivate() {
+        KB_Tracking_Module::clear_cron();
+    }
+}

--- a/includes/class-kb-settings-page.php
+++ b/includes/class-kb-settings-page.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * WooCommerce Einstellungs-Seite für das Plugin.
+ *
+ * @package WooCommerce_KingBear_Adapter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WC_Settings_Page', false ) ) {
+    return;
+}
+
+class KB_Settings_Page extends WC_Settings_Page {
+
+    /**
+     * Module des Plugins.
+     *
+     * @var array
+     */
+    protected $modules = array();
+
+    /**
+     * Konstruktor.
+     *
+     * @param array $modules Geladene Module.
+     */
+    public function __construct( $modules ) {
+        $this->id      = 'kb_adapter';
+        $this->label   = __( 'KingBear Adapter', 'kb' );
+        $this->modules = $modules;
+        parent::__construct();
+    }
+
+    /**
+     * Liefert die Einstellungen.
+     *
+     * @return array
+     */
+    public function get_settings() {
+        $settings = array();
+
+        foreach ( $this->modules as $id => $module ) {
+            if ( ! method_exists( $module, 'get_settings' ) ) {
+                continue;
+            }
+
+            $settings[] = array(
+                'title' => $module->get_title(),
+                'type'  => 'title',
+                'id'    => 'kb_' . $id . '_options',
+            );
+
+            $settings = array_merge( $settings, $module->get_settings() );
+
+            $settings[] = array(
+                'type' => 'sectionend',
+                'id'   => 'kb_' . $id . '_options',
+            );
+        }
+
+        return apply_filters( 'kb_adapter_settings', $settings );
+    }
+}

--- a/modules/tracking/class-kb-tracking-data-store.php
+++ b/modules/tracking/class-kb-tracking-data-store.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Daten-Speicher für KB_Tracking Objekte.
+ *
+ * @package WooCommerce_KingBear_Adapter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! interface_exists( 'WC_Object_Data_Store_Interface', false ) ) {
+    return;
+}
+
+class KB_Tracking_Data_Store implements WC_Object_Data_Store_Interface {
+
+    /**
+     * Option Key für gespeicherte IDs.
+     */
+    const IDS_OPTION = 'kb_tracking_ids';
+
+    public function read( &$tracking ) {
+        $id   = $tracking->get_id();
+        $data = get_option( $this->get_option_key( $id ), array() );
+        if ( ! empty( $data ) && is_array( $data ) ) {
+            $tracking->set_props( $data );
+            $tracking->set_object_read( true );
+        }
+    }
+
+    public function create( &$tracking ) {
+        $id = $tracking->get_id();
+        if ( ! $id ) {
+            $id = $tracking->get_tracking_id();
+            $tracking->set_id( $id );
+        }
+        update_option( $this->get_option_key( $id ), $tracking->get_data() );
+        $this->add_id_to_index( $id );
+        $tracking->set_object_read( true );
+    }
+
+    public function update( &$tracking ) {
+        $id = $tracking->get_id();
+        update_option( $this->get_option_key( $id ), $tracking->get_data() );
+        $this->add_id_to_index( $id );
+    }
+
+    public function delete( &$tracking, $args = array() ) {
+        $id = $tracking->get_id();
+        delete_option( $this->get_option_key( $id ) );
+        $this->remove_id_from_index( $id );
+    }
+
+    protected function get_option_key( $id ) {
+        return 'kb_tracking_' . $id;
+    }
+
+    protected function add_id_to_index( $id ) {
+        $ids = get_option( self::IDS_OPTION, array() );
+        if ( ! in_array( $id, $ids, true ) ) {
+            $ids[] = $id;
+            update_option( self::IDS_OPTION, $ids );
+        }
+    }
+
+    protected function remove_id_from_index( $id ) {
+        $ids = get_option( self::IDS_OPTION, array() );
+        $ids = array_diff( $ids, array( $id ) );
+        update_option( self::IDS_OPTION, $ids );
+    }
+}

--- a/modules/tracking/class-kb-tracking-data.php
+++ b/modules/tracking/class-kb-tracking-data.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Datenobjekt für die Sendungsverfolgung.
+ *
+ * @package WooCommerce_KingBear_Adapter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WC_Data', false ) ) {
+    return;
+}
+
+require_once __DIR__ . '/class-kb-tracking-data-store.php';
+
+class KB_Tracking extends WC_Data {
+
+    protected $object_type = 'kb_tracking';
+
+    protected $data = array(
+        'shipment_id'     => 0,
+        'tracking_id'     => '',
+        'status'          => '',
+        'status_timestamp'=> '',
+        'delivered'       => false,
+        'is_return'       => false,
+        'raw_data'        => array(),
+        'events'          => array(),
+        'do_tracking'     => true,
+    );
+
+    /**
+     * Konstruktor.
+     *
+     * @param int $id Shipment ID.
+     */
+    public function __construct( $id = 0 ) {
+        parent::__construct( $id );
+        $this->data_store = new KB_Tracking_Data_Store();
+        if ( $id ) {
+            $this->set_id( $id );
+            $this->data_store->read( $this );
+        }
+    }
+
+    /**
+     * Speichert das Objekt.
+     */
+    public function save() {
+        if ( 0 === $this->get_id() ) {
+            $this->data_store->create( $this );
+        } else {
+            $this->data_store->update( $this );
+        }
+    }
+
+    /**
+     * ID Getter/Setter (Shipment ID).
+     */
+    public function get_id( $context = 'view' ) {
+        return $this->get_prop( 'shipment_id', $context );
+    }
+
+    public function set_id( $id ) {
+        $this->set_prop( 'shipment_id', absint( $id ) );
+    }
+
+    // Tracking ID.
+    public function get_tracking_id( $context = 'view' ) {
+        return $this->get_prop( 'tracking_id', $context );
+    }
+
+    public function set_tracking_id( $value ) {
+        $this->set_prop( 'tracking_id', wc_clean( $value ) );
+    }
+
+    // Status.
+    public function get_status( $context = 'view' ) {
+        return $this->get_prop( 'status', $context );
+    }
+
+    public function set_status( $value ) {
+        $this->set_prop( 'status', wc_clean( $value ) );
+    }
+
+    // Status Timestamp.
+    public function get_status_timestamp( $context = 'view' ) {
+        return $this->get_prop( 'status_timestamp', $context );
+    }
+
+    public function set_status_timestamp( $value ) {
+        $this->set_prop( 'status_timestamp', wc_clean( $value ) );
+    }
+
+    // Delivered.
+    public function get_delivered( $context = 'view' ) {
+        return (bool) $this->get_prop( 'delivered', $context );
+    }
+
+    public function set_delivered( $value ) {
+        $this->set_prop( 'delivered', (bool) $value );
+    }
+
+    // Is return.
+    public function get_is_return( $context = 'view' ) {
+        return (bool) $this->get_prop( 'is_return', $context );
+    }
+
+    public function set_is_return( $value ) {
+        $this->set_prop( 'is_return', (bool) $value );
+    }
+
+    // Raw data.
+    public function get_raw_data( $context = 'view' ) {
+        return $this->get_prop( 'raw_data', $context );
+    }
+
+    public function set_raw_data( $value ) {
+        $this->set_prop( 'raw_data', (array) $value );
+    }
+
+    // Events.
+    public function get_events( $context = 'view' ) {
+        return $this->get_prop( 'events', $context );
+    }
+
+    public function set_events( $value ) {
+        $this->set_prop( 'events', (array) $value );
+    }
+
+    // Do tracking.
+    public function get_do_tracking( $context = 'view' ) {
+        return (bool) $this->get_prop( 'do_tracking', $context );
+    }
+
+    public function set_do_tracking( $value ) {
+        $this->set_prop( 'do_tracking', (bool) $value );
+    }
+}

--- a/modules/tracking/class-kb-tracking-module.php
+++ b/modules/tracking/class-kb-tracking-module.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Modul Sendungsverfolgung.
+ *
+ * @package WooCommerce_KingBear_Adapter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/class-kb-tracking-data.php';
+
+class KB_Tracking_Module {
+
+    const CRON_HOOK = 'kb_track_shipments';
+
+    public function __construct() {
+        add_filter( 'woocommerce_data_stores', array( $this, 'register_data_store' ) );
+        add_filter( 'cron_schedules', array( $this, 'register_cron_interval' ) );
+        add_action( self::CRON_HOOK, array( $this, 'run_tracking' ) );
+
+        // Platzhalter für Shiptastic Event.
+        add_action( 'shiptastic_shipment_status_ready-for-shipping', array( $this, 'maybe_create_tracking' ) );
+    }
+
+    /**
+     * Anzeigename des Moduls.
+     */
+    public function get_title() {
+        return __( 'Sendungsverfolgung', 'kb' );
+    }
+
+    /**
+     * Einstellungen für das Modul.
+     */
+    public function get_settings() {
+        return array(
+            array(
+                'title' => __( 'DHL API Key', 'kb' ),
+                'id'    => 'kb_tracking_dhl_api_key',
+                'type'  => 'text',
+            ),
+            array(
+                'title' => __( 'DHL API Secret', 'kb' ),
+                'id'    => 'kb_tracking_dhl_api_secret',
+                'type'  => 'text',
+            ),
+            array(
+                'title' => __( 'DHL Benutzername', 'kb' ),
+                'id'    => 'kb_tracking_dhl_username',
+                'type'  => 'text',
+            ),
+            array(
+                'title' => __( 'DHL Passwort', 'kb' ),
+                'id'    => 'kb_tracking_dhl_password',
+                'type'  => 'password',
+            ),
+            array(
+                'title'   => __( 'Logging', 'kb' ),
+                'id'      => 'kb_tracking_log_level',
+                'type'    => 'select',
+                'options' => array(
+                    'error' => __( 'Nur Fehler', 'kb' ),
+                    'debug' => __( 'Fehler und Debug', 'kb' ),
+                ),
+                'default' => 'error',
+            ),
+        );
+    }
+
+    /**
+     * Registriert Cron Event.
+     */
+    public static function schedule_cron() {
+        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+            wp_schedule_event( time(), 'kb_tracking_interval', self::CRON_HOOK );
+        }
+    }
+
+    /**
+     * Entfernt Cron Event.
+     */
+    public static function clear_cron() {
+        $timestamp = wp_next_scheduled( self::CRON_HOOK );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, self::CRON_HOOK );
+        }
+    }
+
+    /**
+     * Cron Intervall (30 Minuten).
+     */
+    public function register_cron_interval( $schedules ) {
+        if ( ! isset( $schedules['kb_tracking_interval'] ) ) {
+            $schedules['kb_tracking_interval'] = array(
+                'interval' => 30 * 60,
+                'display'  => __( 'Every 30 Minutes', 'kb' ),
+            );
+        }
+        return $schedules;
+    }
+
+    /**
+     * Registriert Datastore bei WooCommerce.
+     */
+    public function register_data_store( $stores ) {
+        $stores['kb_tracking'] = 'KB_Tracking_Data_Store';
+        return $stores;
+    }
+
+    /**
+     * Erstellt KB_Tracking Objekte bei Shiptastic Events.
+     *
+     * @param object $shipment Shiptastic Shipment Objekt.
+     */
+    public function maybe_create_tracking( $shipment ) {
+        if ( empty( $shipment ) || empty( $shipment->id ) ) {
+            return;
+        }
+        $tracking = new KB_Tracking( $shipment->id );
+        if ( $tracking->get_tracking_id() ) {
+            return;
+        }
+        $tracking->set_tracking_id( isset( $shipment->tracking_id ) ? $shipment->tracking_id : '' );
+        $tracking->save();
+    }
+
+    /**
+     * Cron Callback.
+     */
+    public function run_tracking() {
+        $ids = get_option( KB_Tracking_Data_Store::IDS_OPTION, array() );
+        if ( empty( $ids ) ) {
+            return;
+        }
+
+        $api_key    = get_option( 'kb_tracking_dhl_api_key' );
+        $api_secret = get_option( 'kb_tracking_dhl_api_secret' );
+        $username   = get_option( 'kb_tracking_dhl_username' );
+        $password   = get_option( 'kb_tracking_dhl_password' );
+        if ( ! $api_key || ! $api_secret || ! $username || ! $password ) {
+            return;
+        }
+
+        $logger   = wc_get_logger();
+        $log_args = array( 'source' => 'kb-tracking' );
+        $debug    = 'debug' === get_option( 'kb_tracking_log_level', 'error' );
+
+        $chunks = array_chunk( $ids, 15 );
+        foreach ( $chunks as $chunk ) {
+            $piece_codes = implode( ';', array_map( 'sanitize_text_field', $chunk ) );
+            $url         = add_query_arg(
+                array(
+                    'request'   => 'd-get-piece-detail',
+                    'piececode' => $piece_codes,
+                ),
+                'https://api-eu.dhl.com/track/shipments'
+            );
+
+            $response = wp_remote_get(
+                $url,
+                array(
+                    'headers' => array(
+                        'dhl-api-key'    => $api_key,
+                        'dhl-api-secret' => $api_secret,
+                    ),
+                    'timeout' => 30,
+                    'auth'    => array( $username, $password ),
+                )
+            );
+
+            if ( is_wp_error( $response ) ) {
+                $logger->error( 'DHL API Fehler: ' . $response->get_error_message(), $log_args );
+                continue;
+            }
+
+            $body = wp_remote_retrieve_body( $response );
+            $xml  = simplexml_load_string( $body );
+
+            if ( ! $xml ) {
+                $logger->error( 'Ungültige Antwort von der DHL API', $log_args );
+                continue;
+            }
+
+            $data = json_decode( wp_json_encode( $xml ), true );
+            if ( empty( $data['data'] ) ) {
+                continue;
+            }
+
+            $shipments = $data['data'];
+            if ( isset( $shipments['@attributes'] ) ) {
+                $shipments = array( $shipments );
+            }
+
+            foreach ( $shipments as $shipment ) {
+                if ( ! isset( $shipment['@attributes']['piece-code'] ) ) {
+                    continue;
+                }
+                $piece    = $shipment['@attributes'];
+                $tracking = new KB_Tracking( $piece['piece-code'] );
+                if ( ! $tracking->get_do_tracking() ) {
+                    continue;
+                }
+                $tracking->set_tracking_id( $piece['piece-code'] );
+                $tracking->set_status( $piece['status'] ?? '' );
+                $tracking->set_status_timestamp( $piece['status-timestamp'] ?? '' );
+                $tracking->set_delivered( isset( $piece['delivery-event-flag'] ) && '1' === (string) $piece['delivery-event-flag'] );
+                $tracking->set_is_return( isset( $piece['ruecksendung'] ) && 'true' === (string) $piece['ruecksendung'] );
+                $tracking->set_raw_data( $piece );
+                if ( isset( $shipment['data'] ) ) {
+                    $tracking->set_events( $shipment['data'] );
+                }
+                $tracking->save();
+                if ( $debug ) {
+                    $logger->debug( 'Tracking aktualisiert: ' . $tracking->get_tracking_id(), $log_args );
+                }
+                if ( $tracking->get_delivered() ) {
+                    // TODO: Status des Shiptastic Shipments auf "shipped" setzen.
+                }
+            }
+        }
+    }
+
+    /**
+     * Admin Seite für Tracking Objekte.
+     */
+    public function render_admin_page() {
+        $ids   = get_option( KB_Tracking_Data_Store::IDS_OPTION, array() );
+        $items = array();
+        foreach ( $ids as $id ) {
+            $items[] = new KB_Tracking( $id );
+        }
+
+        usort(
+            $items,
+            function ( $a, $b ) {
+                return strtotime( $b->get_status_timestamp() ) - strtotime( $a->get_status_timestamp() );
+            }
+        );
+
+        echo '<div class="wrap"><h1>' . esc_html__( 'Sendungsverfolgung', 'kb' ) . '</h1>';
+        echo '<table class="widefat"><thead><tr>';
+        echo '<th>' . esc_html__( 'Zeitstempel', 'kb' ) . '</th>';
+        echo '<th>' . esc_html__( 'Tracking-ID', 'kb' ) . '</th>';
+        echo '<th>' . esc_html__( 'Empfänger', 'kb' ) . '</th>';
+        echo '<th>' . esc_html__( 'Status', 'kb' ) . '</th>';
+        echo '</tr></thead><tbody>';
+
+        foreach ( $items as $item ) {
+            $raw       = $item->get_raw_data();
+            $recipient = array();
+            foreach ( $raw as $key => $value ) {
+                if ( 0 === strpos( $key, 'pan-recipient' ) ) {
+                    $recipient[] = $value;
+                }
+            }
+            $recipient = implode( ', ', array_filter( $recipient ) );
+
+            echo '<tr>';
+            echo '<td>' . esc_html( $item->get_status_timestamp() ) . '</td>';
+            echo '<td>' . esc_html( $item->get_tracking_id() ) . '</td>';
+            echo '<td>' . esc_html( $recipient ) . '</td>';
+            echo '<td>' . esc_html( $item->get_status() ) . '</td>';
+            echo '</tr>';
+        }
+
+        echo '</tbody></table></div>';
+    }
+}

--- a/woocommerce-kingbear-adapter.php
+++ b/woocommerce-kingbear-adapter.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Plugin Name: WooCommerce KingBear Adapter
+ * Description: Modulare Erweiterung für WooCommerce zur Versandabwicklung und Sendungsverfolgung über DHL.
+ * Version: 0.1.0
+ * Author: OpenAI
+ * License: GPL2
+ *
+ * @package WooCommerce_KingBear_Adapter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+require_once __DIR__ . '/includes/class-kb-plugin.php';
+
+// Boot the plugin.
+KB_Plugin::instance();
+
+// Activation & deactivation hooks.
+register_activation_hook( __FILE__, array( 'KB_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'KB_Plugin', 'deactivate' ) );


### PR DESCRIPTION
## Summary
- add main plugin bootstrap and plugin core class
- implement DHL tracking module with cron job, settings and admin list
- document plugin setup and tracking workflow in README

## Testing
- `php -l woocommerce-kingbear-adapter.php`
- `php -l includes/class-kb-plugin.php`
- `php -l includes/class-kb-settings-page.php`
- `php -l modules/tracking/class-kb-tracking-data.php`
- `php -l modules/tracking/class-kb-tracking-data-store.php`
- `php -l modules/tracking/class-kb-tracking-module.php`


------
https://chatgpt.com/codex/tasks/task_e_6895ac8d7498832e8603559d69fd16f1