### PR TITLE
Add activation processing and optional tracking cleanup

### DIFF
--- a/includes/class-kb-plugin.php
+++ b/includes/class-kb-plugin.php
@@ -98,13 +98,19 @@ class KB_Plugin {
      * Plugin Aktivierung.
      */
     public static function activate() {
+        require_once __DIR__ . '/../modules/tracking/class-kb-tracking-module.php';
         KB_Tracking_Module::schedule_cron();
+        KB_Tracking_Module::create_tracking_for_existing_shipments();
     }
 
     /**
      * Plugin Deaktivierung.
      */
     public static function deactivate() {
+        require_once __DIR__ . '/../modules/tracking/class-kb-tracking-module.php';
+        if ( 'yes' === get_option( 'kb_tracking_delete_data', 'no' ) ) {
+            KB_Tracking_Module::delete_all_tracking();
+        }
         KB_Tracking_Module::clear_cron();
     }
 }


### PR DESCRIPTION
## Summary
- create tracking entries for existing Shipments on plugin activation
- add optional setting to remove all tracking data when the plugin is deactivated
- implement routines for cleanup and existing shipment scan

## Testing
- `php -l modules/tracking/class-kb-tracking-module.php`
- `php -l includes/class-kb-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_6895b3ec5058832eb9135505ff296553