### PR TITLE
Fix missing plugin settings page

### DIFF
--- a/includes/class-kb-plugin.php
+++ b/includes/class-kb-plugin.php
@@ -52,7 +52,6 @@ class KB_Plugin {
             return; // Stoppe wenn WooCommerce nicht verfügbar ist.
         }
 
-        require_once __DIR__ . '/class-kb-settings-page.php';
         $this->load_modules();
 
         add_filter( 'woocommerce_get_settings_pages', array( $this, 'register_settings_page' ) );
@@ -74,6 +73,7 @@ class KB_Plugin {
      * @return array
      */
     public function register_settings_page( $pages ) {
+        require_once __DIR__ . '/class-kb-settings-page.php';
         $pages[] = new KB_Settings_Page( $this->modules );
         return $pages;
     }


### PR DESCRIPTION
## Summary
- Load the settings page class when WooCommerce requests it, ensuring the settings tab appears after activation

## Testing
- `php -l includes/class-kb-plugin.php`
- `php -l includes/class-kb-settings-page.php`


------
https://chatgpt.com/codex/tasks/task_e_6895e0d6fc08832e956719c9a03c1e0b