### PR TITLE
Fix DHL tracking event parsing

### DIFF
--- a/modules/tracking/class-kb-tracking-module.php
+++ b/modules/tracking/class-kb-tracking-module.php
@@ -317,6 +317,7 @@ class KB_Tracking_Module {
                 if ( ! isset( $shipment['@attributes']['piece-code'] ) ) {
                     continue;
                 }
+
                 $piece    = $shipment['@attributes'];
                 $tracking = isset( $trackings[ $piece['piece-code'] ] ) ? $trackings[ $piece['piece-code'] ] : new KB_Tracking();
                 $tracking->set_tracking_id( $piece['piece-code'] );
@@ -325,9 +326,21 @@ class KB_Tracking_Module {
                 $tracking->set_delivered( isset( $piece['delivery-event-flag'] ) && '1' === (string) $piece['delivery-event-flag'] );
                 $tracking->set_is_return( isset( $piece['ruecksendung'] ) && 'true' === (string) $piece['ruecksendung'] );
                 $tracking->set_raw_data( $piece );
-                if ( isset( $shipment['data'] ) ) {
-                    $tracking->set_events( $shipment['data'] );
+
+                $events = array();
+                if ( isset( $shipment['data']['data'] ) ) {
+                    $event_items = $shipment['data']['data'];
+                    if ( isset( $event_items['@attributes'] ) ) {
+                        $event_items = array( $event_items );
+                    }
+                    foreach ( $event_items as $event ) {
+                        if ( isset( $event['@attributes'] ) ) {
+                            $events[] = $event['@attributes'];
+                        }
+                    }
                 }
+                $tracking->set_events( $events );
+
                 $tracking->save();
                 if ( $debug ) {
                     $logger->debug( 'Tracking aktualisiert: ' . $tracking->get_tracking_id(), $log_args );


### PR DESCRIPTION
## Summary
- Parse DHL API XML response and iterate over `piece-shipment` nodes
- Extract events from `piece-event-list` and store them in tracking data

## Testing
- `php -l modules/tracking/class-kb-tracking-module.php`


------
https://chatgpt.com/codex/tasks/task_e_6896f971f1f4832eb39a914d02d5af3a